### PR TITLE
Support command line arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Scripts to Back Up and Restore Data Repository Application
 
 These two scripts can be used to back up and restore the Sufia [data repository application](https://github.com/VTUL/data-repo).  The `backup.sh` script is used to back up and `restore.sh` to restore.
 
-Both scripts need to have settings configured to define various attributes about the installed Sufia application.  This is done (for now) by editing the block of settings near the beginning of each script.  The `restore.sh` script takes one argument: the pathname to the directory containing the backup to restore.
+Both scripts need to have settings configured to define various attributes about the installed Sufia application.  This is done (for now) by editing the block of settings near the beginning of each script.  The `restore.sh` script takes one argument: the pathname to the directory containing the backup to restore.  The `backup.sh` can take an optional argument: the pathname to the directory under which backups are stored.  The actual backup will be placed inside a newly-created directory (of the form `backup.YYYY-MM-DD-HHMMSS`) inside the one specified.
 
 When backing up and restoring, the scripts will stop and start the application as necessary, to ensure the files backed up and restored are consistent.
 

--- a/restore.sh
+++ b/restore.sh
@@ -22,12 +22,16 @@ RAILS_LOGS="/home/vagrant/data-repo/log"
 REDIS_DIR=$(redis-cli config get dir|tail -1)
 REDIS_DB=$(redis-cli config get dbfilename|tail -1)
 
+if [ $# -eq 0 ]; then
+  echo "Error: No backup directory specified."
+  exit 1
+fi
 if [ $# -ge 1 ]; then
   BACKUP_DIR="$1"
 fi
 if [ $# -ge 2 ]; then
   shift;
-  echo -n "Ignoring extra arguments: $@"
+  echo "Warning: Ignoring extra arguments: $@"
 fi
 
 # Validate DB_IS_REMOTE


### PR DESCRIPTION
Allow the backup directory to be specified via the command line, if
desired.  If a backups directory is not specified on the command line,
it will fall back on the default BACKUP_ROOT set in the script.

We also ensure that a directory from which to restore is specified as
an argument to restore.sh, as we have no default for that.
