### PR TITLE
Handle PostgreSQL logs

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -8,6 +8,7 @@ DB_USER="vagrant"
 DB_PASS="changeme"
 DB_HOST="localhost"
 DB_PORT="5432"
+DB_IS_REMOTE="NO"
 DB_LOGS="/var/log/postgresql"
 SOLR_DATA="/var/solr/data"
 SOLR_LOGS="/var/solr/logs"
@@ -55,8 +56,10 @@ chmod 0600 "$PGPASSFILE"
 env PGPASSFILE="$PGPASSFILE" pg_dump -Fc -f "${BACKUP_DIR}/pgsqldb.dump" -U $DB_USER -h $DB_HOST -p $DB_PORT $DB_NAME
 echo "DB dumped to ${BACKUP_DIR}/pgsqldb.dump"
 rm "$PGPASSFILE"
-tar -c -z -f "${BACKUP_DIR}/db_logs.tar.gz" -C "$DB_LOGS" .
-echo "DB logs dumped to ${BACKUP_DIR}/db_logs.tar.gz"
+if [ "$DB_IS_REMOTE" = "NO" ]; then
+  tar -c -z -f "${BACKUP_DIR}/db_logs.tar.gz" -C "$DB_LOGS" .
+  echo "DB logs dumped to ${BACKUP_DIR}/db_logs.tar.gz"
+fi
 
 # Copy Solr core data and logs
 tar -c -z -f "${BACKUP_DIR}/solr_data.tar.gz" -C "$SOLR_DATA" .

--- a/restore.sh
+++ b/restore.sh
@@ -73,14 +73,14 @@ if [ "$DB_IS_REMOTE" = "YES" ]; then
   pg_restore -C -d $DB_ADMIN_DB "${BACKUP_DIR}/pgsqldb.dump"
   rm "$PGPASSFILE"
 else
+  tar -x -p -z -f "${BACKUP_DIR}/db_logs.tar.gz" -C "$DB_LOGS" .
+  echo "DB logs restored from ${BACKUP_DIR}/db_logs.tar.gz"
   sudo -u postgres dropdb --if-exists -e $DB_NAME
   sudo -u postgres dropuser --if-exists -e $DB_USER
   sudo -u postgres psql -c "CREATE USER ${DB_USER} WITH PASSWORD '${DB_PASS}';"
   sudo -u postgres pg_restore -C -d postgres "${BACKUP_DIR}/pgsqldb.dump"
 fi
 echo "DB restored from ${BACKUP_DIR}/pgsqldb.dump"
-tar -x -p -z -f "${BACKUP_DIR}/db_logs.tar.gz" -C "$DB_LOGS" .
-echo "DB logs restored from ${BACKUP_DIR}/db_logs.tar.gz"
 
 # Restore Solr core data and logs
 tar -x -p -z -f "${BACKUP_DIR}/solr_data.tar.gz" -C "$SOLR_DATA" .


### PR DESCRIPTION
If the PostgreSQL server is not running locally on the system being
backed up/restored then we need to avoid backing up/restoring the
PostgreSQL server logs because there won't be any on this system.

Note that DB_IS_REMOTE refers to whether the PostgreSQL server is
installed remotely or locally to this system.  It does not strictly
refer to the connection transport used.
