### PR TITLE
Alter service order

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -40,9 +40,9 @@ fi
 # Shut down services to quiesce them
 echo "Stopping VTechData services..."
 service nginx stop
+service resque-pool stop
 service solr stop
 service tomcat7 stop
-service resque-pool stop
 
 echo "VTechData services stopped."
 
@@ -89,9 +89,9 @@ echo "Redis queue dumped to ${BACKUP_DIR}/redis_queue.tar.gz"
 
 # Start up services again
 echo "Starting VTechData services..."
-service resque-pool start
 service tomcat7 start
 service solr start
+service resque-pool start
 service nginx start
 
 echo "VTechData services started."

--- a/restore.sh
+++ b/restore.sh
@@ -49,9 +49,9 @@ esac
 # Shut down services to quiesce them
 echo "Stopping VTechData services..."
 service nginx stop
+service resque-pool stop
 service solr stop
 service tomcat7 stop
-service resque-pool stop
 
 echo "VTechData services stopped."
 
@@ -115,9 +115,9 @@ sudo -H -u $APP_USER bundle exec rake tmp:clear
 
 # Start up services again
 echo "Starting VTechData services..."
-service resque-pool start
 service tomcat7 start
 service solr start
+service resque-pool start
 service nginx start
 
 echo "VTechData services started."


### PR DESCRIPTION
We move the order in which the resque-pool service is started up and
shut down to be more correct.

Previously, resque-pool was shut down after Solr and Fedora had been
stopped, which is wrong because some of the background jobs may call
upon Sufia services involving Solr and Fedora.  Such jobs would fail if
Solr or Fedora went away before they had been correctly terminated.

Stopping resque-pool before the shutdown of Solr and Fedora, and
starting it up after Solr and Fedora have started seems the safer and
more logical sequence.
